### PR TITLE
Use actual values for security checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ pipask install requests --dry-run
 
 Pipask performs these checks before allowing installation:
 
-* **Repository popularity** - verification of links from PyPI to repositories, number of stars on GitHub or GitLab source repo (warning below 1000 stars)
+* **Repository popularity** - verification of links from PyPI to repositories, number of stars on GitHub or GitLab source repo (warning below 1000 stars with bold warning below 100)
 * **Package and release age** - warning for new packages (less than 22 days old) or stale releases (older than 365 days)
 * **Known vulnerabilities** in the package available in PyPI (failure for HIGH or CRITICAL vulnerabilities, warning for MODERATE vulnerabilities)
-* **Number of downloads** from PyPI in the last month (warning below 1000 downloads)
+* **Number of downloads** from PyPI in the last month (failure below 100 downloads and warning below 5000)
 * **Metadata verification**: Checks for license availability, development status, and yanked packages
 
 All checks are executed for requested (i.e., explicitly specified) packages. Only the known vulnerabilities check is executed for transitive dependencies.


### PR DESCRIPTION
Hello! This project is awesome!) Thanks for making Python ecosystem more secure.

Found that there is some numbers mismatch (probably from earlier versions of `pipask`), so I would like to edit them in `README.md` to help end user :)

Repo popularity contains two constants:
Warning before 1000 stars and **bold warning below 100** https://github.com/feynmanix/pipask/blob/08adad73d08b0cb7b8578801153a9f81e243a3dd/src/pipask/checks/repo_popularity.py#L10

Number of downloads raises warning below 1000 **-> 5000** downloads https://github.com/feynmanix/pipask/blob/08adad73d08b0cb7b8578801153a9f81e243a3dd/src/pipask/checks/package_downloads.py#L6